### PR TITLE
Add deployment configuration for documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,6 @@ makedocs(;
     ])
 
 deploydocs(;
-    repo="https://github.com/tensor4all/QuanticsGrids.jl",
+    repo="github.com/tensor4all/QuanticsGrids.jl.git",
     devbranch="main",
 )


### PR DESCRIPTION
We forgot that we need to add the `deploydocs` function. 