### PR TITLE
Remove unused `Test` module import

### DIFF
--- a/test/code_quality_test.jl
+++ b/test/code_quality_test.jl
@@ -1,5 +1,4 @@
 @testitem "Code quality (Aqua.jl)" begin
-    using Test
     using Aqua
 
     import QuanticsGrids

--- a/test/code_quality_test.jl
+++ b/test/code_quality_test.jl
@@ -15,7 +15,7 @@ end
 
     import QuanticsGrids
 
-    if VERSION >= v"1.9"
+    if VERSION >= v"1.10"
         @testset "Code linting (JET.jl)" begin
             JET.test_package(QuanticsGrids; target_defined_modules = true)
         end


### PR DESCRIPTION
It seems that we do not need to import the "Test.jl" package when testing with Aqua.jl.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/d27f91c1-cd1b-4b6a-943c-333eae140c4f">
