### PR TITLE
Run tests for Julia LTS (v1.10) and latest stable (v1.11)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Julia 1.11 has been released and Julia v1.10 is now LTS. 
We would like to check tests for LTS and the latest stable.