### PR TITLE
7 invalid grid max for includeendpoint=false

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,22 +1,18 @@
 using QuanticsGrids
 using Documenter
 
-DocMeta.setdocmeta!(QuanticsGrids, :DocTestSetup, :(using QuanticsGrids); recursive=true)
+DocMeta.setdocmeta!(QuanticsGrids, :DocTestSetup, :(using QuanticsGrids); recursive = true)
 
 makedocs(;
-    modules=[QuanticsGrids],
-    authors="Ritter.Marc <Ritter.Marc@physik.uni-muenchen.de> and contributors",
-    sitename="QuanticsGrids.jl",
-    format=Documenter.HTML(;
-        canonical="https://github.com/tensor4all/QuanticsGrids.jl",
-        edit_link="main",
-        assets=String[]),
-    pages=[
-        "Home" => "index.md",
-        "API Reference" => "apireference.md",
-    ])
-
-deploydocs(;
-    repo="github.com/tensor4all/QuanticsGrids.jl.git",
-    devbranch="main",
+    modules = [QuanticsGrids],
+    authors = "Ritter.Marc <Ritter.Marc@physik.uni-muenchen.de> and contributors",
+    sitename = "QuanticsGrids.jl",
+    format = Documenter.HTML(;
+        canonical = "https://github.com/tensor4all/QuanticsGrids.jl",
+        edit_link = "main",
+        assets = String[],
+    ),
+    pages = ["Home" => "index.md", "API Reference" => "apireference.md"],
 )
+
+deploydocs(; repo = "github.com/tensor4all/QuanticsGrids.jl.git", devbranch = "main")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,10 +85,10 @@ We can create a one-dimensional grid by discretizing $x$ axis on $[0, 1)$ with $
 
 ```@example simple
 import QuanticsGrids as QD
-xmin = 0.0
-xmax = 1.0
+xlower = 0.0
+xupper = 1.0
 R = 4
-grid = QD.DiscretizedGrid{1}(R, xmin, xmax)
+grid = QD.DiscretizedGrid{1}(R, xlower, xupper)
 ```
 
 Here, `DiscretizedGrid` takes one parameter `1`, which denotes the dimension of the grid.
@@ -124,13 +124,13 @@ Optionally, one can include the end point `grid_max` in a grid as
 
 ```@example simple
 import QuanticsGrids as QD
-xmin = 0.0
-xmax = 1.0
+xlower = 0.0
+xupper = 1.0
 R = 4
-grid = QD.DiscretizedGrid{1}(R, xmin, xmax; includeendpoint=true)
+grid = QD.DiscretizedGrid{1}(R, xlower, xupper; includeendpoint=true)
 
-@assert QD.grididx_to_origcoord(grid, 1) == xmin
-@assert QD.grididx_to_origcoord(grid, 2^R) == xmax
+@assert QD.grididx_to_origcoord(grid, 1) == xlower
+@assert QD.grididx_to_origcoord(grid, 2^R) == xupper
 ```
 
 ## Creating a $d$-dimensional grid
@@ -140,11 +140,11 @@ As an option, you can choose the fused representation (`:fused`) or the interlea
 ### fused representation
 ```@example simple
 import QuanticsGrids as QD
-xmin, xmax = 0.0, 1.0
-ymin, ymax = 0.0, 1.0
-zmin, zmax = 0.0, 1.0
+xlower, xupper = 0.0, 1.0
+ylower, yupper = 0.0, 1.0
+zlower, zupper = 0.0, 1.0
 R = 4
-grid = QD.DiscretizedGrid{3}(R, (xmin,ymin,zmin), (xmax,ymax,zmax); unfoldingscheme=:fused)
+grid = QD.DiscretizedGrid{3}(R, (xlower,ylower,zlower), (xupper,yupper,zupper); unfoldingscheme=:fused)
 
 quantics = fill(1, R)
 origcoord = (0.0, 0.0, 0.0)
@@ -171,11 +171,11 @@ grididx = (2, 1, 1)
 ### Interleaved representation
 ```@example simple
 import QuanticsGrids as QD
-xmin, xmax = 0.0, 1.0
-ymin, ymax = 0.0, 1.0
-zmin, zmax = 0.0, 1.0
+xlower, xupper = 0.0, 1.0
+ylower, yupper = 0.0, 1.0
+zlower, zupper = 0.0, 1.0
 R = 4
-grid = QD.DiscretizedGrid{3}(R, (xmin,ymin,zmin), (xmax,ymax,zmax); unfoldingscheme=:interleaved)
+grid = QD.DiscretizedGrid{3}(R, (xlower,ylower,zlower), (xupper,yupper,zupper); unfoldingscheme=:interleaved)
 
 # (x1, y1, z1, ...., xR, yR, zR)
 quantics = fill(1, 3R) # length is 3R

--- a/example/chern/chern.jl
+++ b/example/chern/chern.jl
@@ -12,30 +12,30 @@ include("kanemele.jl")
 include("latticeplot.jl")
 include("berry.jl")
 
-function maxlinkdim(n::Integer, localdim::Integer=2)
-    return 0:n-2, [min(localdim^i, localdim^(n - i)) for i in 1:(n-1)]
+function maxlinkdim(n::Integer, localdim::Integer = 2)
+    return 0:n-2, [min(localdim^i, localdim^(n - i)) for i = 1:(n-1)]
 end
 
 function sumqtt(qtt)
-    return prod(sum(T, dims=2)[:, 1, :] for T in qtt)[1]
+    return prod(sum(T, dims = 2)[:, 1, :] for T in qtt)[1]
 end
 
 function sum_quantics_mps(mps)
     m = mps[1] * ITensor(1, siteind(mps, 1))
-    for i in 2:length(mps)
+    for i = 2:length(mps)
         m *= mps[i] * ITensor(1, siteind(mps, i))
     end
     return scalar(m)
 end
 
 function mps_to_array(mps)
-    result = Vector{Array{Float64, 3}}()
+    result = Vector{Array{Float64,3}}()
     T1 = Array(mps[1], siteind(mps, 1), linkind(mps, 1))
     push!(result, reshape(T1, 1, size(T1)...))
-    for i in 2:length(mps)-1
-        push!(result, Array(mps[i], linkind(mps, i-1), siteind(mps, i), linkind(mps, i)))
+    for i = 2:length(mps)-1
+        push!(result, Array(mps[i], linkind(mps, i - 1), siteind(mps, i), linkind(mps, i)))
     end
-    Tlast = Array(mps[end], linkind(mps, length(mps)-1), siteind(mps, length(mps)))
+    Tlast = Array(mps[end], linkind(mps, length(mps) - 1), siteind(mps, length(mps)))
     push!(result, reshape(Tlast, size(Tlast)..., 1))
     return result
 end
@@ -64,14 +64,17 @@ function getberryqtt_dets(
     lattice::TCI.IndexSet{HoneycombSite},
     q::Integer,
     lambdaSO::Float64;
-    spinindex=1,
-    tolerance=1e-12
+    spinindex = 1,
+    tolerance = 1e-12,
 )
     Hcached = TCI.CachedFunction{Matrix{ComplexF64}}(
-        kindex -> get_H(
-            q, lambdaSO, [kxvals[kindex[1]], kyvals[kindex[2]]], lattice
-        )[:, spinindex, :, spinindex],
-        [2^nquantics, 2^nquantics]
+        kindex -> get_H(q, lambdaSO, [kxvals[kindex[1]], kyvals[kindex[2]]], lattice)[
+            :,
+            spinindex,
+            :,
+            spinindex,
+        ],
+        [2^nquantics, 2^nquantics],
     )
 
     f = functioncounter(k -> berrycurvature_quantics_dets(Hcached, n, k, nquantics))
@@ -82,9 +85,9 @@ function getberryqtt_dets(
         f,
         fill(2, 2 * nquantics),
         firstpivot,
-        tolerance=tolerance,
-        maxiter=200,
-        verbosity=1,
+        tolerance = tolerance,
+        maxiter = 200,
+        verbosity = 1,
     )
     qtt = TCI.tensortrain(tci)
     return sumqtt(qtt) / 2pi, qtt, ranks, errors, f.n
@@ -99,18 +102,17 @@ function getberrymps_dets(
     lattice::TCI.IndexSet{HoneycombSite},
     q::Integer,
     lambdaSO::Float64;
-    spinindex=1,
-    tolerance=1e-12
+    spinindex = 1,
+    tolerance = 1e-12,
 )
     H = [
-        get_H(q, lambdaSO, [kx, ky], lattice)[:, spinindex, :, spinindex]
-        for kx in kxvals, ky in kyvals
+        get_H(q, lambdaSO, [kx, ky], lattice)[:, spinindex, :, spinindex] for
+        kx in kxvals, ky in kyvals
     ]
-    quanticsindices = [
-        Index(2, i % 2 == 0 ? "qx$(div(i, 2))" : "qy$(div(i, 2))") for i in 1:2nquantics
-    ]
+    quanticsindices =
+        [Index(2, i % 2 == 0 ? "qx$(div(i, 2))" : "qy$(div(i, 2))") for i = 1:2nquantics]
     A = ITensor(berrycurvature_dets(H, n), quanticsindices)
-    mps = MPS(A, quanticsindices, cutoff=tolerance, maxdim=200)
+    mps = MPS(A, quanticsindices, cutoff = tolerance, maxdim = 200)
     return sum_quantics_mps(mps) / 2pi, mps_to_array(mps), linkdims(mps), prod(size(A))
 end
 
@@ -122,11 +124,27 @@ function getberryqtt_derivs(
     lattice::TCI.IndexSet{HoneycombSite},
     q::Integer,
     lambdaSO::Float64;
-    spinindex=1,
-    tolerance=1e-12
+    spinindex = 1,
+    tolerance = 1e-12,
 )
-    Hfunc(kindex) = get_H(q, lambdaSO, [kxvals[kindex[1]], kyvals[kindex[2]]], lattice)[:, spinindex, :, spinindex]
-    Hderivfunc(kindex, derivdirection) = get_H(q, lambdaSO, [kxvals[kindex[1]], kyvals[kindex[2]]], lattice, derivative_direction=derivdirection)[:, spinindex, :, spinindex]
+    Hfunc(kindex) = get_H(q, lambdaSO, [kxvals[kindex[1]], kyvals[kindex[2]]], lattice)[
+        :,
+        spinindex,
+        :,
+        spinindex,
+    ]
+    Hderivfunc(kindex, derivdirection) = get_H(
+        q,
+        lambdaSO,
+        [kxvals[kindex[1]], kyvals[kindex[2]]],
+        lattice,
+        derivative_direction = derivdirection,
+    )[
+        :,
+        spinindex,
+        :,
+        spinindex,
+    ]
     f = functioncounter(k -> berrycurvature_quantics_derivatives(Hfunc, Hderivfunc, n, k))
     firstpivot = TCI.optfirstpivot(f, fill(2, 2 * nquantics))
     f.n = 0
@@ -135,9 +153,9 @@ function getberryqtt_derivs(
         f,
         fill(2, 2 * nquantics),
         firstpivot,
-        tolerance=tolerance,
-        maxiter=200,
-        verbosity=1,
+        tolerance = tolerance,
+        maxiter = 200,
+        verbosity = 1,
     )
     qtt = TCI.tensortrain(tci)
     return sumqtt(qtt) / 2pi, qtt, ranks, errors, f.n
@@ -158,7 +176,7 @@ struct BerryResult
     mpstimeestimate::Float64
 end
 
-function testberry(q::Integer, lambdaSO::Float64, nquantics=5:10)
+function testberry(q::Integer, lambdaSO::Float64, nquantics = 5:10)
     lattice = honeycomblattice(0, 1, 0, q - 1)
 
     BZedgex = pi / 1.5
@@ -166,25 +184,40 @@ function testberry(q::Integer, lambdaSO::Float64, nquantics=5:10)
     results = BerryResult[]
     for nq in nquantics
         ndiscretization = 2^nq
-        kxvals = collect(range(-BZedgex, BZedgex; length=ndiscretization)) .+ (BZedgex / ndiscretization)
-        kyvals = collect(range(-BZedgey, BZedgey; length=ndiscretization)) .+ (BZedgey / ndiscretization)
-        timeestimate = @elapsed result = getberryqtt_dets(nq, kxvals, kyvals, 2q, lattice, q, lambdaSO, tolerance=1e-5)
-        mpstime = @elapsed mpsresult = getberrymps_dets(nq, kxvals, kyvals, 2q, lattice, q, lambdaSO, tolerance=1e-5)
-        push!(
-            results,
-            BerryResult(
-                nq,
-                result...,
-                timeestimate,
-                mpsresult...,
-                mpstime
-            ))
+        kxvals =
+            collect(range(-BZedgex, BZedgex; length = ndiscretization)) .+
+            (BZedgex / ndiscretization)
+        kyvals =
+            collect(range(-BZedgey, BZedgey; length = ndiscretization)) .+
+            (BZedgey / ndiscretization)
+        timeestimate = @elapsed result = getberryqtt_dets(
+            nq,
+            kxvals,
+            kyvals,
+            2q,
+            lattice,
+            q,
+            lambdaSO,
+            tolerance = 1e-5,
+        )
+        mpstime = @elapsed mpsresult = getberrymps_dets(
+            nq,
+            kxvals,
+            kyvals,
+            2q,
+            lattice,
+            q,
+            lambdaSO,
+            tolerance = 1e-5,
+        )
+        push!(results, BerryResult(nq, result..., timeestimate, mpsresult..., mpstime))
         println(
             "Finished nq = $nq.
             Chern number from qtt is $(last(results).chernnumber).
             Time elapsed is $timeestimate for $(last(results).nevals) function evaluations.
             Chern number from mps is $(last(results).chernnumbermps).
-            Time elapsed is $mpstime for $(last(results).mpsnevals) function evaluations.")
+            Time elapsed is $mpstime for $(last(results).mpsnevals) function evaluations.",
+        )
     end
     return results
 end

--- a/example/chern/evaluatechern.jl
+++ b/example/chern/evaluatechern.jl
@@ -7,16 +7,18 @@ nq = parse(Int, ARGS[1])
 
 result = chern.testberry(4, 0.2, nq)[1]
 
-jldsave("chern_results/nq$nq.jld2";
-    nq=result.nq,
-    chernnumber=result.chernnumber,
-    qtt=result.qtt,
-    ranks=result.ranks,
-    errors=result.errors,
-    nevals=result.nevals,
-    timeestimate=result.timeestimate,
-    chernnumbermps=result.chernnumbermps,
-    mps=result.mps,
-    mpsranks=result.mpsranks,
-    mpsnevals=result.mpsnevals,
-    mpstimeestimate=result.mpstimeestimate)
+jldsave(
+    "chern_results/nq$nq.jld2";
+    nq = result.nq,
+    chernnumber = result.chernnumber,
+    qtt = result.qtt,
+    ranks = result.ranks,
+    errors = result.errors,
+    nevals = result.nevals,
+    timeestimate = result.timeestimate,
+    chernnumbermps = result.chernnumbermps,
+    mps = result.mps,
+    mpsranks = result.mpsranks,
+    mpsnevals = result.mpsnevals,
+    mpstimeestimate = result.mpstimeestimate,
+)

--- a/example/chern/haldane.jl
+++ b/example/chern/haldane.jl
@@ -4,27 +4,18 @@ using JLD2
 
 include("chern.jl")
 
-pauli0 = [1. 0.; 0. 1.]
-pauli = [
-    [0. 1.; 1. 0.],
-    [0. -1.0im; 1.0im 0.],
-    [1. 0.; 0. -1.]
-]
+pauli0 = [1.0 0.0; 0.0 1.0]
+pauli = [[0.0 1.0; 1.0 0.0], [0.0 -1.0im; 1.0im 0.0], [1.0 0.0; 0.0 -1.0]]
 
 antisymmetricproduct(u, v) = u[1] * v[2] - u[2] * v[1]
 
 function haldane(k, t2, ϕ, m)
-    a::Vector{Vector{Float64}} =
-    [
-        [1, 0],
-        [-0.5, 0.5sqrt(3)],
-        [-0.5, -0.5sqrt(3)]
-    ]
+    a::Vector{Vector{Float64}} = [[1, 0], [-0.5, 0.5sqrt(3)], [-0.5, -0.5sqrt(3)]]
     b::Vector{Vector{Float64}} = [a[2] - a[3], a[3] - a[1], a[1] - a[2]]
 
     return 2 * t2 * cos(ϕ) * sum(cos(k' * bi) for bi in b) * pauli0 +    # NNN hopping
-        sum(cos(k' * ai) * pauli[1] + sin(k' * ai) * pauli[2] for ai in a) + # NN hopping
-        (m - 2 * t2 * sin(ϕ) * sum(sin(k' * bi) for bi in b)) * pauli[3]    # staggered offset
+           sum(cos(k' * ai) * pauli[1] + sin(k' * ai) * pauli[2] for ai in a) + # NN hopping
+           (m - 2 * t2 * sin(ϕ) * sum(sin(k' * bi) for bi in b)) * pauli[3]    # staggered offset
 end
 
 function scalar(a::Matrix)
@@ -41,9 +32,9 @@ end
 
 struct cachedfunc{ValueType}
     f::Function
-    d::Dict{Vector{Int}, ValueType}
+    d::Dict{Vector{Int},ValueType}
 
-    function cachedfunc(::Type{ValueType}, f::Function) where ValueType
+    function cachedfunc(::Type{ValueType}, f::Function) where {ValueType}
         new{ValueType}(f, Dict())
     end
 end
@@ -61,31 +52,31 @@ end
 Base.broadcastable(x::cachedfunc) = Ref(x)
 
 function sumqtt(qtt)
-    return prod(sum(T, dims=2)[:, 1, :] for T in qtt)[1]
+    return prod(sum(T, dims = 2)[:, 1, :] for T in qtt)[1]
 end
 
-function maxrelerror(f, qtt::Vector{Array{Float64, 3}}, indices::Vector{Vector{Int}})
+function maxrelerror(f, qtt::Vector{Array{Float64,3}}, indices::Vector{Vector{Int}})
     return maximum(abs(f(i) - evaluate_qtt(qtt, i)) / abs(f(i)) for i in indices)
- end
+end
 
- function maxabserror(f, qtt::Vector{Array{Float64, 3}}, indices::Vector{Vector{Int}})
-     return maximum(abs(f(i) - evaluate_qtt(qtt, i)) for i in indices)
- end
+function maxabserror(f, qtt::Vector{Array{Float64,3}}, indices::Vector{Vector{Int}})
+    return maximum(abs(f(i) - evaluate_qtt(qtt, i)) for i in indices)
+end
 
 function crossinterpolate_chern(
     ::Type{ValueType},
     f,
     localdims::Vector{Int},
-    firstpivot::TCI.MultiIndex=ones(Int, length(localdims));
-    tolerance::Float64=1e-8,
-    maxiter::Int=200,
-    sweepstrategy::TCI.SweepStrategies.SweepStrategy=TCI.SweepStrategies.back_and_forth,
-    pivottolerance::Float64=1e-12,
-    normalizeerror=true,
-    verbosity::Int=0,
-    additionalpivots::Vector{TCI.MultiIndex}=TCI.MultiIndex[],
-    evalooserror::Bool=false,
-    oosindices::Vector{TCI.MultiIndex}=[rand([1, 2], length(localdims)) for _ in 1:2000],
+    firstpivot::TCI.MultiIndex = ones(Int, length(localdims));
+    tolerance::Float64 = 1e-8,
+    maxiter::Int = 200,
+    sweepstrategy::TCI.SweepStrategies.SweepStrategy = TCI.SweepStrategies.back_and_forth,
+    pivottolerance::Float64 = 1e-12,
+    normalizeerror = true,
+    verbosity::Int = 0,
+    additionalpivots::Vector{TCI.MultiIndex} = TCI.MultiIndex[],
+    evalooserror::Bool = false,
+    oosindices::Vector{TCI.MultiIndex} = [rand([1, 2], length(localdims)) for _ = 1:2000],
 ) where {ValueType}
     tci = TCI.TensorCI{ValueType}(f, localdims, firstpivot)
     n = length(tci)
@@ -101,7 +92,7 @@ function crossinterpolate_chern(
         println("Rank $(TCI.rank(tci))")
     end
 
-    for iter in TCI.rank(tci)+1:maxiter
+    for iter = TCI.rank(tci)+1:maxiter
         foward_sweep = (
             sweepstrategy == TCI.SweepStrategies.forward ||
             (sweepstrategy != TCI.SweepStrategies.backward && isodd(iter))
@@ -126,7 +117,9 @@ function crossinterpolate_chern(
 
         if verbosity > 0 && (mod(iter, 10) == 0 || last(errors) < tolerance)
             if evalooserror
-                println("rank = $(last(ranks)), error = $(last(errors)), chern = $(last(cherns))")
+                println(
+                    "rank = $(last(ranks)), error = $(last(errors)), chern = $(last(cherns))",
+                )
             else
                 println("rank = $(last(ranks)), error = $(last(errors))")
             end
@@ -145,24 +138,27 @@ end
 function evaluatechern_haldane(
     deltam::Float64,
     nquantics::Int;
-    t2::Float64=1e-1,
-    tolerance::Float64=1e-4,
-    evalooserror::Bool=false,
+    t2::Float64 = 1e-1,
+    tolerance::Float64 = 1e-4,
+    evalooserror::Bool = false,
 )
-    phi = pi/2
+    phi = pi / 2
     m = 3sqrt(3) * t2 + deltam
-    domainboundx = [-4pi/3, 4pi/3]
-    domainboundy = [-6pi/(3sqrt(3)), 6pi/(3sqrt(3))]
+    domainboundx = [-4pi / 3, 4pi / 3]
+    domainboundy = [-6pi / (3sqrt(3)), 6pi / (3sqrt(3))]
 
     ndiscretization = 2^nquantics
-    kxvals = range(domainboundx..., length=ndiscretization+1)#[2:end]
+    kxvals = range(domainboundx..., length = ndiscretization + 1)#[2:end]
     kxvals = 0.5 .* (kxvals[1:ndiscretization] .+ kxvals[2:end])
-    kyvals = range(domainboundy..., length=ndiscretization+1)#[2:end]
+    kyvals = range(domainboundy..., length = ndiscretization + 1)#[2:end]
     kyvals = 0.5 .* (kyvals[1:ndiscretization] .+ kyvals[2:end])
 
     f(q) = chern.berrycurvature_quantics_dets(
         kindex -> haldane([kxvals[kindex[1]], kyvals[kindex[2]]], t2, phi, m),
-        1, q, nquantics)
+        1,
+        q,
+        nquantics,
+    )
 
     localdims = fill(4, nquantics)
     #cf = TCI.CachedFunction{Float64}(f, localdims)
@@ -176,16 +172,16 @@ function evaluatechern_haldane(
     firstpivot = TCI.optfirstpivot(cf, localdims)
     println("$firstpivot, $(cf(firstpivot))")
 
-        # [2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 1, 2, 1, 2, 2,
-        #     2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1][1:2*nquantics])
+    # [2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 1, 2, 1, 2, 2,
+    #     2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1][1:2*nquantics])
     additionalpivots = []
-        # TCI.optfirstpivot(cf, localdims,
-        # [2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 1, 2, 1, 2, 2,
-        #     2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1][1:2*nquantics]),
-        # TCI.optfirstpivot(cf, localdims),
-        # TCI.optfirstpivot(cf, localdims, localdims)]
-        # TCI.optfirstpivot(cf, localdims, repeat([1, 2], nquantics)),
-        # TCI.optfirstpivot(cf, localdims, repeat([2, 1], nquantics))]
+    # TCI.optfirstpivot(cf, localdims,
+    # [2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 1, 2, 1, 2, 2,
+    #     2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 1][1:2*nquantics]),
+    # TCI.optfirstpivot(cf, localdims),
+    # TCI.optfirstpivot(cf, localdims, localdims)]
+    # TCI.optfirstpivot(cf, localdims, repeat([1, 2], nquantics)),
+    # TCI.optfirstpivot(cf, localdims, repeat([2, 1], nquantics))]
     # sort!(additionalpivots, by=abs ∘ cf, rev=true)
     # for a in additionalpivots
     #     println(a, cf(a))
@@ -196,23 +192,24 @@ function evaluatechern_haldane(
     cutxvals = 1:cutxstep:ndiscretization
     cutystep = div(ndiscretization, 8192)
     oosindices = [
-        index_to_quantics([kxi, kyi], nquantics)
-        for kxi in cutxvals, kyi in 684:cutystep:ndiscretization
+        index_to_quantics([kxi, kyi], nquantics) for kxi in cutxvals,
+        kyi = 684:cutystep:ndiscretization
     ]
 
-    walltime = @elapsed tci, ranks, errors, cherns, inserrors, ooserrors = crossinterpolate_chern(
-        Float64,
-        cf,
-        localdims,
-        firstpivot,
-        tolerance=tolerance,
-        maxiter=200,
-        verbosity=1,
-        pivottolerance=1e-16,
-        #additionalpivots = additionalpivots,
-        evalooserror=evalooserror,
-        oosindices=oosindices[:]
-    )
+    walltime =
+        @elapsed tci, ranks, errors, cherns, inserrors, ooserrors = crossinterpolate_chern(
+            Float64,
+            cf,
+            localdims,
+            firstpivot,
+            tolerance = tolerance,
+            maxiter = 200,
+            verbosity = 1,
+            pivottolerance = 1e-16,
+            #additionalpivots = additionalpivots,
+            evalooserror = evalooserror,
+            oosindices = oosindices[:],
+        )
 
     chernnumber = NaN
     if !evalooserror
@@ -225,23 +222,23 @@ function evaluatechern_haldane(
     println("δm = $deltam, R = $nquantics : C = $chernnumber")
 
     savepath::String = (
-        evalooserror
-        ? "example/chern/haldane_results_oos/nq$(nquantics)_deltam$(deltam).jld2"
-        : "example/chern/haldane_results/nq$(nquantics)_deltam$(deltam).jld2"
+        evalooserror ?
+        "example/chern/haldane_results_oos/nq$(nquantics)_deltam$(deltam).jld2" :
+        "example/chern/haldane_results/nq$(nquantics)_deltam$(deltam).jld2"
     )
 
     jldsave(
         savepath;
-        deltam=deltam,
-        nquantics=nquantics,
-        cherns=cherns,
-        chernnumber=chernnumber,
-        tci=tci,
-        ranks=ranks,
-        errors=errors,
-        nevals=length(cf.d),
-        walltime=walltime,
-        inserrors=inserrors,
-        ooserrors=ooserrors
+        deltam = deltam,
+        nquantics = nquantics,
+        cherns = cherns,
+        chernnumber = chernnumber,
+        tci = tci,
+        ranks = ranks,
+        errors = errors,
+        nevals = length(cf.d),
+        walltime = walltime,
+        inserrors = inserrors,
+        ooserrors = ooserrors,
     )
 end

--- a/example/chern/honeycomb.jl
+++ b/example/chern/honeycomb.jl
@@ -17,7 +17,7 @@ function Base.isequal(l::HoneycombSite, r::HoneycombSite)
 end
 
 function Base.hash(s::HoneycombSite, h::UInt)
-    return foldr(hash, [s.R, s.c, :HoneycombSite]; init=h)
+    return foldr(hash, [s.R, s.c, :HoneycombSite]; init = h)
 end
 
 function realspacecoordinates(s::HoneycombSite)
@@ -32,13 +32,13 @@ function neighbours(s::HoneycombSite)
         return [
             HoneycombSite(s.R, 2),
             HoneycombSite(s.R + [-1, 0], 2),
-            HoneycombSite(s.R + [-1, 1], 2)
+            HoneycombSite(s.R + [-1, 1], 2),
         ]
     else
         return [
             HoneycombSite(s.R, 1),
             HoneycombSite(s.R + [1, 0], 1),
-            HoneycombSite(s.R + [1, -1], 1)
+            HoneycombSite(s.R + [1, -1], 1),
         ]
     end
 end
@@ -50,20 +50,17 @@ function nextneighbours(s::HoneycombSite)
         HoneycombSite(s.R + [-1, 0], s.c),
         HoneycombSite(s.R + [-1, 1], s.c),
         HoneycombSite(s.R + [0, 1], s.c),
-        HoneycombSite(s.R + [0, -1], s.c)
+        HoneycombSite(s.R + [0, -1], s.c),
     ]
 end
 
 function reducesite(s::HoneycombSite, Lx::Int, Ly::Int)
     xnew = mod(s.R[1], 2 * Lx)
-    return HoneycombSite(
-        [xnew, mod(s.R[2] - div(xnew - s.R[1], 2), Ly)],
-        s.c
-    )
+    return HoneycombSite([xnew, mod(s.R[2] - div(xnew - s.R[1], 2), Ly)], s.c)
 end
 
 function honeycomblattice(xmin::Integer, xmax::Integer, ymin::Integer, ymax::Integer)
     return TCI.IndexSet(
-        [HoneycombSite([x, y], c) for c in 1:2, x in xmin:xmax, y in ymin:ymax][:]
+        [HoneycombSite([x, y], c) for c = 1:2, x = xmin:xmax, y = ymin:ymax][:],
     )
 end

--- a/example/chern/kanemele.jl
+++ b/example/chern/kanemele.jl
@@ -7,11 +7,7 @@ function peierls(B::Real, i::HoneycombSite, j::HoneycombSite)
 end
 
 function rashba(distance::Vector{Float64})
-    pauli = [
-        [0. 1.; 1. 0.],
-        [0. -1.0im; 1.0im 0.],
-        [1. 0.; 0. -1.]
-    ]
+    pauli = [[0.0 1.0; 1.0 0.0], [0.0 -1.0im; 1.0im 0.0], [1.0 0.0; 0.0 -1.0]]
 
     return pauli[1] .* distance[2] .- pauli[2] .* distance[1]
 end
@@ -20,8 +16,8 @@ function get_Ht(
     q::Integer,
     k::Vector{Float64},
     lattice::TCI.IndexSet{HoneycombSite};
-    mass::Float64=0.0,
-    derivative_direction::Union{Nothing,Int}=nothing
+    mass::Float64 = 0.0,
+    derivative_direction::Union{Nothing,Int} = nothing,
 )
     B = 4pi / sqrt(3) / q
     Ht = zeros(ComplexF64, 4q, 2, 4q, 2)
@@ -51,7 +47,7 @@ function get_HR(
     q::Integer,
     k::Vector{Float64},
     lattice::TCI.IndexSet{HoneycombSite};
-    derivative_direction::Union{Nothing,Int}=nothing
+    derivative_direction::Union{Nothing,Int} = nothing,
 )
     @assert isnothing(derivative_direction)
 
@@ -75,7 +71,7 @@ function get_Hlambda(
     q::Integer,
     k::Vector{Float64},
     lattice::TCI.IndexSet{HoneycombSite};
-    derivative_direction::Union{Nothing,Int}=nothing
+    derivative_direction::Union{Nothing,Int} = nothing,
 )
     B = 4pi / sqrt(3) / q
     Hlambda = zeros(ComplexF64, 4q, 2, 4q, 2)
@@ -106,10 +102,10 @@ function get_H(
     lambda_R::Float64,
     k::Vector{Float64},
     lattice::TCI.IndexSet{HoneycombSite};
-    mass::Float64=0.0,
-    derivative_direction::Union{Nothing,Int}=nothing
+    mass::Float64 = 0.0,
+    derivative_direction::Union{Nothing,Int} = nothing,
 )
     return get_Ht(q, k, lattice; mass, derivative_direction) .+
-        lambda_SO .* get_Hlambda(q, k, lattice; derivative_direction) .+
-        lambda_R .* get_HR(q, k, lattice)
+           lambda_SO .* get_Hlambda(q, k, lattice; derivative_direction) .+
+           lambda_R .* get_HR(q, k, lattice)
 end

--- a/example/chern/latticeplot.jl
+++ b/example/chern/latticeplot.jl
@@ -2,15 +2,15 @@ function displayhamiltonian(
     ax,
     H::Matrix{Float64},
     lattice::TCI.IndexSet;
-    vmax::Float64=maximum(abs.(H)),
-    cm=get_cmap("Purples")
+    vmax::Float64 = maximum(abs.(H)),
+    cm = get_cmap("Purples"),
 )
     ax.set_aspect(1)
 
     for s in lattice.fromint
         for n in neighbours(s)
             rs, rn = realspacecoordinates.([s, n])
-            ax.plot([rs[1], rn[1]], [rs[2], rn[2]], color="gray", linewidth=0.5)
+            ax.plot([rs[1], rn[1]], [rs[2], rn[2]], color = "gray", linewidth = 0.5)
         end
     end
 
@@ -19,10 +19,12 @@ function displayhamiltonian(
         for (j, rj) in enumerate(coords)
             value = H[i, j] / vmax
             ax.plot(
-                [ri[1], rj[1]], [ri[2], rj[2]],
-                color=cm(value),
-                zorder=1 + value,
-                alpha=0.5)
+                [ri[1], rj[1]],
+                [ri[2], rj[2]],
+                color = cm(value),
+                zorder = 1 + value,
+                alpha = 0.5,
+            )
         end
     end
 end

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -27,11 +27,11 @@ end
 function localdimensions(g::Grid{d}) where {d}
     return fill(
         digitmax(d, g.base, g.unfoldingscheme),
-        quanticslength(g.R, d, g.unfoldingscheme)
+        quanticslength(g.R, d, g.unfoldingscheme),
     )
 end
 
-function _rangecheck_R(R; base=2)::Int
+function _rangecheck_R(R; base = 2)::Int
     base * (BigInt(base)^R - 1) ÷ (base - 1) <= typemax(Int) ||
         error("R too large for base $base")
 end
@@ -67,12 +67,12 @@ grid index => quantics
 """
 function grididx_to_quantics(g::Grid{d}, grididx::NTuple{d,Int}) where {d}
     if g.unfoldingscheme === :fused
-        return index_to_quantics_fused(grididx, numdigits=g.R, base=g.base)
+        return index_to_quantics_fused(grididx, numdigits = g.R, base = g.base)
     else
         return fused_to_interleaved(
-            index_to_quantics_fused(grididx, numdigits=g.R, base=g.base),
+            index_to_quantics_fused(grididx, numdigits = g.R, base = g.base),
             d,
-            base=g.base,
+            base = g.base,
         )
     end
 end
@@ -103,9 +103,9 @@ function quantics_to_grididx(g::Grid{d}, bitlist) where {d}
     return _convert_to_scalar_if_possible(
         quantics_to_index(
             bitlist;
-            base=g.base,
-            dims=Val(d),
-            unfoldingscheme=g.unfoldingscheme,
+            base = g.base,
+            dims = Val(d),
+            unfoldingscheme = g.unfoldingscheme,
         ),
     )
 end
@@ -150,11 +150,11 @@ struct InherentDiscreteGrid{d} <: Grid{d}
     function InherentDiscreteGrid{d}(
         R::Int,
         origin::Union{NTuple{d,Int},Int};
-        base::Integer=2,
-        unfoldingscheme::Symbol=:fused,
-        step::Union{NTuple{d,Int},Int}=1,
+        base::Integer = 2,
+        unfoldingscheme::Symbol = :fused,
+        step::Union{NTuple{d,Int},Int} = 1,
     ) where {d}
-        _rangecheck_R(R; base=base)
+        _rangecheck_R(R; base = base)
         unfoldingscheme in (:fused, :interleaved) ||
             error("Invalid unfolding scheme: $unfoldingscheme")
         origin_ = origin isa Int ? ntuple(i -> origin, d) : origin
@@ -167,30 +167,32 @@ end
 function InherentDiscreteGrid(
     R::Int,
     origin::Int;
-    base::Integer=2,
-    unfoldingscheme::Symbol=:fused,
-    step::Int=1,
+    base::Integer = 2,
+    unfoldingscheme::Symbol = :fused,
+    step::Int = 1,
 )
     return InherentDiscreteGrid{1}(
-        R, origin;
-        base=base,
-        unfoldingscheme=unfoldingscheme,
-        step=step,
+        R,
+        origin;
+        base = base,
+        unfoldingscheme = unfoldingscheme,
+        step = step,
     )
 end
 
 function InherentDiscreteGrid(
     R::Int,
-    origin::NTuple{N, Int};
-    base::Integer=2,
-    unfoldingscheme::Symbol=:fused,
-    step::Union{Int, NTuple{N, Int}}=1,
+    origin::NTuple{N,Int};
+    base::Integer = 2,
+    unfoldingscheme::Symbol = :fused,
+    step::Union{Int,NTuple{N,Int}} = 1,
 ) where {N}
     return InherentDiscreteGrid{N}(
-        R, origin;
-        base=base,
-        unfoldingscheme=unfoldingscheme,
-        step=step,
+        R,
+        origin;
+        base = base,
+        unfoldingscheme = unfoldingscheme,
+        step = step,
     )
 end
 
@@ -210,7 +212,9 @@ grid_min(grid::InherentDiscreteGrid) = _convert_to_scalar_if_possible(grid.origi
 Returns the grid point with maximal coordinate values.
 The return value is scalar for 1D grids, and a `Tuple` otherwise.
 """
-grid_max(grid::InherentDiscreteGrid) = _convert_to_scalar_if_possible(grid.origin .+ grid_step(grid) .* (grid.base^grid.R .- 1))
+grid_max(grid::InherentDiscreteGrid) = _convert_to_scalar_if_possible(
+    grid.origin .+ grid_step(grid) .* (grid.base^grid.R .- 1),
+)
 
 """
     grid_step(g::InherentDiscreteGrid)
@@ -237,16 +241,16 @@ Create a grid for inherently discrete data with origin at 1
 """
 function InherentDiscreteGrid{d}(
     R::Int;
-    base::Integer=2,
-    step::Union{NTuple{d,Int},Int}=1,
-    unfoldingscheme::Symbol=:fused,
+    base::Integer = 2,
+    step::Union{NTuple{d,Int},Int} = 1,
+    unfoldingscheme::Symbol = :fused,
 ) where {d}
     InherentDiscreteGrid{d}(
         R,
         1;
-        base=base,
-        unfoldingscheme=unfoldingscheme,
-        step=step,
+        base = base,
+        unfoldingscheme = unfoldingscheme,
+        step = step,
     )
 end
 
@@ -296,11 +300,11 @@ struct DiscretizedGrid{d} <: Grid{d}
         R::Int,
         lower_bound,
         upper_bound;
-        base::Integer=2,
-        unfoldingscheme::Symbol=:fused,
-        includeendpoint::Bool=false,
+        base::Integer = 2,
+        unfoldingscheme::Symbol = :fused,
+        includeendpoint::Bool = false,
     ) where {d}
-        _rangecheck_R(R; base=base)
+        _rangecheck_R(R; base = base)
         unfoldingscheme in (:fused, :interleaved) ||
             error("Invalid unfolding scheme: $unfoldingscheme")
         return new(
@@ -322,15 +326,17 @@ function DiscretizedGrid(
     R::Int,
     grid_min::T,
     grid_max::T;
-    base::Integer=2,
-    unfoldingscheme::Symbol=:fused,
-    includeendpoint::Bool=false,
-) where {T <: Real}
+    base::Integer = 2,
+    unfoldingscheme::Symbol = :fused,
+    includeendpoint::Bool = false,
+) where {T<:Real}
     return DiscretizedGrid{1}(
-        R, (grid_min,), (grid_max,);
-        base=base,
-        unfoldingscheme=unfoldingscheme,
-        includeendpoint=includeendpoint,
+        R,
+        (grid_min,),
+        (grid_max,);
+        base = base,
+        unfoldingscheme = unfoldingscheme,
+        includeendpoint = includeendpoint,
     )
 end
 
@@ -340,17 +346,19 @@ Create a discretized grid for a d-dimensional space
 """
 function DiscretizedGrid(
     R::Int,
-    grid_min::NTuple{d, T},
-    grid_max::NTuple{d, T};
-    base::Integer=2,
-    unfoldingscheme::Symbol=:fused,
-    includeendpoint::Bool=false,
-) where {d, T <: Real}
+    grid_min::NTuple{d,T},
+    grid_max::NTuple{d,T};
+    base::Integer = 2,
+    unfoldingscheme::Symbol = :fused,
+    includeendpoint::Bool = false,
+) where {d,T<:Real}
     return DiscretizedGrid{d}(
-        R, grid_min, grid_max;
-        base=base,
-        unfoldingscheme=unfoldingscheme,
-        includeendpoint=includeendpoint,
+        R,
+        grid_min,
+        grid_max;
+        base = base,
+        unfoldingscheme = unfoldingscheme,
+        includeendpoint = includeendpoint,
     )
 end
 
@@ -375,7 +383,9 @@ Returns the grid point with maximal coordinate values.
  - If `includeendpoint=true` during creation of the grid, this function is equivalent to [`upper_bound`](@ref).
 The return value is scalar for 1D grids, and a `Tuple` otherwise.
 """
-grid_max(g::DiscretizedGrid) = g.includeendpoint ? _convert_to_scalar_if_possible(g.upper_bound) : _convert_to_scalar_if_possible(g.upper_bound .- grid_step(g))
+grid_max(g::DiscretizedGrid) =
+    g.includeendpoint ? _convert_to_scalar_if_possible(g.upper_bound) :
+    _convert_to_scalar_if_possible(g.upper_bound .- grid_step(g))
 
 """
     grid_step(g::DiscretizedGrid)
@@ -384,9 +394,8 @@ Returns the distance between adjacent grid points in each dimension.
 The return value is scalar for 1D grids, and a `Tuple` otherwise.
 """
 grid_step(g::DiscretizedGrid{d}) where {d} = _convert_to_scalar_if_possible(
-    g.includeendpoint ?
-    (g.upper_bound .- g.lower_bound) ./ (g.base^g.R .- 1) :
-    (g.upper_bound .- g.lower_bound) ./ (g.base^g.R)
+    g.includeendpoint ? (g.upper_bound .- g.lower_bound) ./ (g.base^g.R .- 1) :
+    (g.upper_bound .- g.lower_bound) ./ (g.base^g.R),
 )
 
 """
@@ -408,17 +417,13 @@ The return value is scalar for 1D grids, and a `Tuple` otherwise.
 """
 lower_bound(g::DiscretizedGrid) = _convert_to_scalar_if_possible(g.lower_bound)
 
-function DiscretizedGrid{d}(
-    R::Int;
-    base=2,
-    unfoldingscheme::Symbol=:fused,
-) where {d}
+function DiscretizedGrid{d}(R::Int; base = 2, unfoldingscheme::Symbol = :fused) where {d}
     return DiscretizedGrid{d}(
         R,
         ntuple(i -> 0.0, d),
         ntuple(i -> 1.0, d);
-        base=base,
-        unfoldingscheme=unfoldingscheme,
+        base = base,
+        unfoldingscheme = unfoldingscheme,
     )
 end
 
@@ -427,8 +432,9 @@ end
 Convert a coordinate in the original coordinate system to the corresponding grid index
 """
 function origcoord_to_grididx(g::DiscretizedGrid, coordinate::NTuple{N,Float64}) where {N}
-    all(lower_bound(g) .<= coordinate .<= upper_bound(g)) ||
-        error("Bound Error: $(coordinate), lower_bound=$(lower_bound(g)), upper_bound=$(upper_bound(g))")
+    all(lower_bound(g) .<= coordinate .<= upper_bound(g)) || error(
+        "Bound Error: $(coordinate), lower_bound=$(lower_bound(g)), upper_bound=$(upper_bound(g))",
+    )
     clip(x) = max.(1, min.(x, g.base^g.R))
     return _convert_to_scalar_if_possible(
         ((coordinate .- grid_min(g)) ./ grid_step(g) .+ 1) .|> round .|> Int,

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -252,14 +252,53 @@ struct DiscretizedGrid{d} <: Grid{d}
     end
 end
 
+"""
+    grid_min(g::DiscretizedGrid)
+
+Returns the grid point with minimal coordinate values.
+This is equivalent to [`lower_bound`](@ref).
+The return value is scalar for 1D grids, and a `Tuple` otherwise.
+"""
 grid_min(g::DiscretizedGrid) = _convert_to_scalar_if_possible(g.lower_bound)
+
+"""
+    grid_max(g::DiscretizedGrid)
+
+Returns the grid point with maximal coordinate values.
+ - If `includeendpoint=false` during creation of the grid, this value is dependent on grid resolution.
+ - If `includeendpoint=true` during creation of the grid, this function is equivalent to [`upper_bound`](@ref).
+The return value is scalar for 1D grids, and a `Tuple` otherwise.
+"""
 grid_max(g::DiscretizedGrid) = g.includeendpoint ? _convert_to_scalar_if_possible(g.upper_bound) : _convert_to_scalar_if_possible(g.upper_bound .- grid_step(g))
+
+"""
+    grid_step(g::DiscretizedGrid)
+
+Returns the distance between adjacent grid points in each dimension.
+The return value is scalar for 1D grids, and a `Tuple` otherwise.
+"""
 grid_step(g::DiscretizedGrid{d}) where {d} = _convert_to_scalar_if_possible(
     g.includeendpoint ?
     (g.upper_bound .- g.lower_bound) ./ (g.base^g.R .- 1) :
     (g.upper_bound .- g.lower_bound) ./ (g.base^g.R)
 )
+"""
+    upper_bound(g::DiscretizedGrid)
+
+Returns the upper bound of the grid coordinates, as passed to the constructor during grid creation.
+ - If `includeendpoint=false` during grid creation, this function returns a point that is one grid spacing beyond the last grid point (which can be obtained through [`grid_max`](@ref)).
+ - If `includeendpoint=true` during grid creation, this function returns the point with maximal coordinate values. This is equivalent to [`grid_max`](@ref).
+The return value is scalar for 1D grids, and a `Tuple` otherwise.
+"""
 upper_bound(g::DiscretizedGrid) = _convert_to_scalar_if_possible(g.upper_bound)
+
+"""
+    grid_min(g::DiscretizedGrid)
+
+Returns the grid point with minimal coordinate values, as passed to the constructor during grid creation.
+This is equivalent to [`grid_min`](@ref).
+The return value is scalar for 1D grids, and a `Tuple` otherwise.
+"""
 lower_bound(g::DiscretizedGrid) = _convert_to_scalar_if_possible(g.lower_bound)
 
 function DiscretizedGrid{d}(

--- a/src/quantics.jl
+++ b/src/quantics.jl
@@ -12,15 +12,15 @@ scale (see QTCI paper).
 
 Inverse of [`unfuse_dimensions`](@ref).
 """
-function fuse_dimensions(digitlists...; base::Integer=2)
+function fuse_dimensions(digitlists...; base::Integer = 2)
     _checkdigits.(base, digitlists)
     result = ones(Int, length(digitlists[1]))
-    return fuse_dimensions!(result, digitlists...; base=base)
+    return fuse_dimensions!(result, digitlists...; base = base)
 end
 
 
 
-function fuse_dimensions!(fused::AbstractArray{<:Integer}, digitlists...; base::Integer=2)
+function fuse_dimensions!(fused::AbstractArray{<:Integer}, digitlists...; base::Integer = 2)
     p = 1
     fused .= 1
     for d in eachindex(digitlists)
@@ -37,18 +37,18 @@ end
 Unfuse up a fused digitlist with bits of dimension base^d into d digitlists where each bit has dimension `base`.
 Inverse of [`fuse_dimensions`](@ref).
 """
-function unfuse_dimensions(digitlist, d; base::Integer=2)
+function unfuse_dimensions(digitlist, d; base::Integer = 2)
     result = [zeros(Int, length(digitlist)) for _ = 1:d]
-    return unfuse_dimensions!(result, digitlist; base=base)
+    return unfuse_dimensions!(result, digitlist; base = base)
 end
 
-function unfuse_dimensions!(digitlists, digitlist; base::Integer=2)
+function unfuse_dimensions!(digitlists, digitlist; base::Integer = 2)
     ndim = length(digitlists)
     R = length(digitlist)
     for i = 1:ndim
         for j = 1:R
             digitlists[i][j] =
-                _digit_at_index(digitlist[j], ndim - i + 1; numdigits=ndim, base=base)
+                _digit_at_index(digitlist[j], ndim - i + 1; numdigits = ndim, base = base)
         end
     end
     return digitlists
@@ -109,9 +109,9 @@ Convert a fused quantics representation to an unfused quantics representation
 function fused_to_interleaved(
     digitlist::AbstractVector{T},
     d;
-    base=2,
+    base = 2,
 )::Vector{T} where {T<:Integer}
-    return interleave_dimensions(unfuse_dimensions(digitlist, d; base=base)...)
+    return interleave_dimensions(unfuse_dimensions(digitlist, d; base = base)...)
 end
 
 """
@@ -119,8 +119,8 @@ Convert an unfused quantics representation to an fused quantics representation
 """
 function interleaved_to_fused(
     digitlist::AbstractVector{T};
-    base::Integer=2,
-    d::Int=1,
+    base::Integer = 2,
+    d::Int = 1,
 )::Vector{T} where {T<:Integer}
     fused_digitlist = Vector{T}(undef, length(digitlist) ÷ d)
     fuse_dimensions!(fused_digitlist, deinterleave_dimensions(digitlist, d)...)
@@ -143,8 +143,8 @@ See also [`quantics_to_index`](https://tensors4fields.gitlab.io/quanticstci.jl/d
 """
 function quantics_to_index_fused(
     digitlist::AbstractVector{<:Integer};
-    base::Integer=2,
-    dims::Val{d}=Val(1),
+    base::Integer = 2,
+    dims::Val{d} = Val(1),
 )::NTuple{d,Int} where {d}
     R = length(digitlist)
     result = ones(MVector{d,Int})
@@ -181,17 +181,17 @@ Convert a d-dimensional index from fused quantics representation to d Integers.
 """
 function quantics_to_index(
     digitlist::AbstractVector{<:Integer};
-    base::Integer=2,
-    dims::Val{d}=Val(1),
-    unfoldingscheme::Symbol=:fused,
+    base::Integer = 2,
+    dims::Val{d} = Val(1),
+    unfoldingscheme::Symbol = :fused,
 )::NTuple{d,Int} where {d}
     if unfoldingscheme === :fused
-        return quantics_to_index_fused(digitlist, base=base, dims=dims)
+        return quantics_to_index_fused(digitlist, base = base, dims = dims)
     else
         return quantics_to_index_fused(
-            interleaved_to_fused(digitlist; base=base, d=d),
-            base=base,
-            dims=dims,
+            interleaved_to_fused(digitlist; base = base, d = d),
+            base = base,
+            dims = dims,
         )
     end
 end
@@ -203,7 +203,7 @@ end
 * `digitlist`     base-b representation (1d vector)
 * `base`           base for quantics (default: 2)
 """
-function index_to_quantics!(digitlist, index::Integer; base::Integer=2)
+function index_to_quantics!(digitlist, index::Integer; base::Integer = 2)
     numdigits = length(digitlist)
     for i = 1:numdigits
         digitlist[i] = mod(index - 1, base^(numdigits - i + 1)) ÷ base^(numdigits - i) + 1
@@ -216,9 +216,9 @@ end
 
 Does the same as [`index_to_quantics!`](@ref) but returns a new vector.
 """
-function index_to_quantics(index::Integer; numdigits=8, base::Integer=2)
+function index_to_quantics(index::Integer; numdigits = 8, base::Integer = 2)
     digitlist = Vector{Int}(undef, numdigits)
-    return index_to_quantics!(digitlist, index; base=base)
+    return index_to_quantics!(digitlist, index; base = base)
 end
 
 """
@@ -229,7 +229,7 @@ Does the opposite of [`quantics_to_index_fused`](@ref)
 function index_to_quantics_fused!(
     digitlist::AbstractVector{<:Integer},
     index::NTuple{D,<:Integer};
-    base::Integer=2,
+    base::Integer = 2,
 ) where {D}
     R = length(digitlist)
     ndims = length(index)
@@ -238,7 +238,7 @@ function index_to_quantics_fused!(
         for i = 1:R # from the left to right
             digitlist[i] +=
                 (base^(dim - 1)) *
-                (_digit_at_index(index[dim], i; numdigits=R, base=base) - 1)
+                (_digit_at_index(index[dim], i; numdigits = R, base = base) - 1)
         end
     end
     return digitlist
@@ -246,11 +246,11 @@ end
 
 function index_to_quantics_fused(
     index::NTuple{D,<:Integer};
-    numdigits::Integer=8,
-    base::Integer=2,
+    numdigits::Integer = 8,
+    base::Integer = 2,
 ) where {D}
     digitlist = Vector{Int}(undef, numdigits)
-    return index_to_quantics_fused!(digitlist, index; base=base)
+    return index_to_quantics_fused!(digitlist, index; base = base)
 end
 
 
@@ -262,7 +262,7 @@ end
 `position=1`: Specify the position of the digit to look at. 1 is the most significant (most left) digit.
 `numdigits=8`: Specify the number of digits in the number `index`.
 """
-function _digit_at_index(index, position; numdigits=8, base::Integer=2)
+function _digit_at_index(index, position; numdigits = 8, base::Integer = 2)
     p_ = numdigits - position + 1
     return mod((index - 1), base^p_) ÷ base^(p_ - 1) + 1
 end

--- a/src/quantics.jl
+++ b/src/quantics.jl
@@ -104,7 +104,7 @@ function deinterleave_dimensions!(
 end
 
 """
-Converrt a fused qunaitcs representation to an unfused quantics representation
+Convert a fused quantics representation to an unfused quantics representation
 """
 function fused_to_interleaved(
     digitlist::AbstractVector{T},
@@ -115,7 +115,7 @@ function fused_to_interleaved(
 end
 
 """
-Converrt a unfused qunaitcs representation to an fused quantics representation
+Convert a unfused quantics representation to an fused quantics representation
 """
 function interleaved_to_fused(
     digitlist::AbstractVector{T};
@@ -225,8 +225,6 @@ end
     index_to_quantics_fused!(digitlist::AbstractVector{<:Integer}, index::NTuple{D,<:Integer}; base::Integer=2) where {D}
 
 Does the opposite of [`quantics_to_index_fused`](@ref)
-
-* `D`
 """
 function index_to_quantics_fused!(
     digitlist::AbstractVector{<:Integer},

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -123,8 +123,12 @@
             ) == 2
             @test QuanticsGrids.origcoord_to_grididx(g, 1.999999 * dx + a) == 3
             @test QuanticsGrids.origcoord_to_grididx(g, QuanticsGrids.grid_max(g) + 1e-9 * dx) == 2^R
+
             @test QuanticsGrids.lower_bound(g) == 0.1
             @test QuanticsGrids.upper_bound(g) == 2.0
+            @test QuanticsGrids.grid_min(g) == a
+            @test QuanticsGrids.grid_max(g) == b - dx
+
             @test QuanticsGrids.grid_step(g) == 0.059375
         end
 
@@ -141,6 +145,11 @@
                 includeendpoint=true,
             )
             @test QuanticsGrids.localdimensions(g) == fill(2, R)
+
+            @test QuanticsGrids.lower_bound(g) == 0.0
+            @test QuanticsGrids.upper_bound(g) == 1.0
+            @test QuanticsGrids.grid_min(g) == a
+            @test QuanticsGrids.grid_max(g) == b
 
             @test @inferred(QuanticsGrids.origcoord_to_grididx(g, a)) == 1
             @test @inferred(QuanticsGrids.origcoord_to_grididx(g, b)) == 2^R
@@ -165,6 +174,9 @@
             @test QuanticsGrids.lower_bound(g) == (0.1, 0.1)
             @test QuanticsGrids.grid_step(g) == dx == (0.059375, 0.059375)
             @test QuanticsGrids.upper_bound(g) == (2.0, 2.0)
+
+            @test QuanticsGrids.grid_min(g) == a
+            @test QuanticsGrids.grid_max(g) == b .- dx
 
             cs = [
                 0.999999 .* dx .+ a,

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -23,8 +23,9 @@
     @testset "2D grid (large R)" for base in [2]
         R = 62
         d = 2
-        grid = QuanticsGrids.DiscretizedGrid{d}(R, 0.0, 1.0; base=base)
-        @test QuanticsGrids.grididx_to_quantics(grid, ntuple(i -> base^R, d)) == fill(base^d, R)
+        grid = QuanticsGrids.DiscretizedGrid{d}(R, 0.0, 1.0; base = base)
+        @test QuanticsGrids.grididx_to_quantics(grid, ntuple(i -> base^R, d)) ==
+              fill(base^d, R)
     end
 
     @testset "1D grid (too large R)" begin
@@ -82,7 +83,7 @@
         step in [(1, 1, 1), (1, 1, 2)],
         origin in [(1, 1, 1), (1, 1, 2)]
 
-        m = QuanticsGrids.InherentDiscreteGrid{3}(5, origin; unfoldingscheme, step=step)
+        m = QuanticsGrids.InherentDiscreteGrid{3}(5, origin; unfoldingscheme, step = step)
         @test QuanticsGrids.grid_min(m) == origin
         @test QuanticsGrids.grid_step(m) == step
 
@@ -118,11 +119,12 @@
             g = QuanticsGrids.DiscretizedGrid{1}(R, a, b; unfoldingscheme)
             @test QuanticsGrids.localdimensions(g) == fill(2, R)
 
-            @test @inferred(
-                QuanticsGrids.origcoord_to_grididx(g, 0.999999 * dx + a)
-            ) == 2
+            @test @inferred(QuanticsGrids.origcoord_to_grididx(g, 0.999999 * dx + a)) == 2
             @test QuanticsGrids.origcoord_to_grididx(g, 1.999999 * dx + a) == 3
-            @test QuanticsGrids.origcoord_to_grididx(g, QuanticsGrids.grid_max(g) + 1e-9 * dx) == 2^R
+            @test QuanticsGrids.origcoord_to_grididx(
+                g,
+                QuanticsGrids.grid_max(g) + 1e-9 * dx,
+            ) == 2^R
 
             @test QuanticsGrids.lower_bound(g) == 0.1
             @test QuanticsGrids.upper_bound(g) == 2.0
@@ -142,7 +144,7 @@
                 a,
                 b;
                 unfoldingscheme,
-                includeendpoint=true,
+                includeendpoint = true,
             )
             @test QuanticsGrids.localdimensions(g) == fill(2, R)
 
@@ -178,11 +180,7 @@
             @test QuanticsGrids.grid_min(g) == a
             @test QuanticsGrids.grid_max(g) == b .- dx
 
-            cs = [
-                0.999999 .* dx .+ a,
-                1.999999 .* dx .+ a,
-                b .- dx .- 1e-9 .* dx,
-            ]
+            cs = [0.999999 .* dx .+ a, 1.999999 .* dx .+ a, b .- dx .- 1e-9 .* dx]
             refs = [2, 3, 2^R]
 
             for (c, ref) in zip(cs, refs)
@@ -210,7 +208,7 @@
                 a,
                 b;
                 unfoldingscheme,
-                includeendpoint=true,
+                includeendpoint = true,
             )
             @test g.includeendpoint
             @test QuanticsGrids.grid_step(g) == dx
@@ -238,8 +236,16 @@
         @test QuanticsGrids.grid_max(g2) == QuanticsGrids.grid_max(g2_ref)
         @test QuanticsGrids.upper_bound(g2) == QuanticsGrids.upper_bound(g2_ref)
 
-        g6 = QuanticsGrids.DiscretizedGrid(6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
-        g6_ref = QuanticsGrids.DiscretizedGrid{6}(6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
+        g6 = QuanticsGrids.DiscretizedGrid(
+            6,
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+        )
+        g6_ref = QuanticsGrids.DiscretizedGrid{6}(
+            6,
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+        )
         @test g6 isa QuanticsGrids.DiscretizedGrid{6}
         @test QuanticsGrids.grid_min(g6) == QuanticsGrids.grid_min(g6_ref)
         @test QuanticsGrids.grid_max(g6) == QuanticsGrids.grid_max(g6_ref)
@@ -249,7 +255,7 @@
         @test g3 isa QuanticsGrids.InherentDiscreteGrid{1}
         @test QuanticsGrids.grid_origin(g3) == 1
 
-        g4 = QuanticsGrids.InherentDiscreteGrid(4, (1, 2, 3); step=(1, 2, 1))
+        g4 = QuanticsGrids.InherentDiscreteGrid(4, (1, 2, 3); step = (1, 2, 1))
         @test g4 isa QuanticsGrids.InherentDiscreteGrid{3}
         @test QuanticsGrids.grid_origin(g4) == (1, 2, 3)
         @test QuanticsGrids.grid_step(g4) == (1, 2, 1)

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -109,50 +109,52 @@
 
     @testset "DiscretizedGrid" for unfoldingscheme in [:interleaved, :fused]
         @testset "1D" begin
+            unfoldingscheme = :interleaved
+
             R = 5
-            grid_min = 0.1
-            grid_max = 2.0
-            dx = (grid_max - grid_min) / 2^R
-            g = QuanticsGrids.DiscretizedGrid{1}(R, grid_min, grid_max; unfoldingscheme)
+            a = 0.1
+            b = 2.0
+            dx = (b - a) / 2^R
+            g = QuanticsGrids.DiscretizedGrid{1}(R, a, b; unfoldingscheme)
             @test QuanticsGrids.localdimensions(g) == fill(2, R)
 
             @test @inferred(
-                QuanticsGrids.origcoord_to_grididx(g, 0.999999 * dx + grid_min)
-            ) == 1
-            @test QuanticsGrids.origcoord_to_grididx(g, 1.999999 * dx + grid_min) == 2
-            @test QuanticsGrids.origcoord_to_grididx(g, grid_max - 1e-9 * dx) == 2^R
-            @test QuanticsGrids.grid_min(g) == 0.1
-            @test QuanticsGrids.grid_max(g) == 2.0
+                QuanticsGrids.origcoord_to_grididx(g, 0.999999 * dx + a)
+            ) == 2
+            @test QuanticsGrids.origcoord_to_grididx(g, 1.999999 * dx + a) == 3
+            @test QuanticsGrids.origcoord_to_grididx(g, QuanticsGrids.grid_max(g) + 1e-9 * dx) == 2^R
+            @test QuanticsGrids.lower_bound(g) == 0.1
+            @test QuanticsGrids.upper_bound(g) == 2.0
             @test QuanticsGrids.grid_step(g) == 0.059375
         end
 
         @testset "1D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused]
             R = 5
-            grid_min = 0.0
-            grid_max = 1.0
-            dx = (grid_max - grid_min) / (2^R - 1)
+            a = 0.0
+            b = 1.0
+            dx = (b - a) / (2^R - 1)
             g = QuanticsGrids.DiscretizedGrid{1}(
                 R,
-                grid_min,
-                grid_max;
+                a,
+                b;
                 unfoldingscheme,
                 includeendpoint=true,
             )
             @test QuanticsGrids.localdimensions(g) == fill(2, R)
 
-            @test @inferred(QuanticsGrids.origcoord_to_grididx(g, grid_min)) == 1
-            @test @inferred(QuanticsGrids.origcoord_to_grididx(g, grid_max)) == 2^R
+            @test @inferred(QuanticsGrids.origcoord_to_grididx(g, a)) == 1
+            @test @inferred(QuanticsGrids.origcoord_to_grididx(g, b)) == 2^R
             @test only(QuanticsGrids.grid_step(g)) == dx
-            @test only(QuanticsGrids.quantics_to_origcoord(g, fill(2, R))) == grid_max
+            @test only(QuanticsGrids.quantics_to_origcoord(g, fill(2, R))) == b
         end
 
         @testset "2D" for unfoldingscheme in [:interleaved, :fused]
             R = 5
             d = 2
-            grid_min = (0.1, 0.1)
-            grid_max = (2.0, 2.0)
-            dx = (grid_max .- grid_min) ./ 2^R
-            g = QuanticsGrids.DiscretizedGrid{d}(R, grid_min, grid_max; unfoldingscheme)
+            a = (0.1, 0.1)
+            b = (2.0, 2.0)
+            dx = (b .- a) ./ 2^R
+            g = QuanticsGrids.DiscretizedGrid{d}(R, a, b; unfoldingscheme)
 
             if unfoldingscheme === :interleaved
                 @test QuanticsGrids.localdimensions(g) == fill(2, d * R)
@@ -160,19 +162,20 @@
                 @test QuanticsGrids.localdimensions(g) == fill(2^d, R)
             end
 
-            @test QuanticsGrids.grid_min(g) == (0.1, 0.1)
+            @test QuanticsGrids.lower_bound(g) == (0.1, 0.1)
             @test QuanticsGrids.grid_step(g) == dx == (0.059375, 0.059375)
-            @test QuanticsGrids.grid_max(g) == (2.0, 2.0)
+            @test QuanticsGrids.upper_bound(g) == (2.0, 2.0)
 
             cs = [
-                0.999999 .* dx .+ grid_min,
-                1.999999 .* dx .+ grid_min,
-                grid_max .- 1e-9 .* dx,
+                0.999999 .* dx .+ a,
+                1.999999 .* dx .+ a,
+                b .- 1e-9 .* dx,
             ]
-            refs = [1, 2, 2^R]
+            refs = [2, 3, 2^R]
 
             for (c, ref) in zip(cs, refs)
                 @inferred(QuanticsGrids.origcoord_to_grididx(g, c))
+                @show QuanticsGrids.origcoord_to_grididx(g, c), ref
                 @test all(QuanticsGrids.origcoord_to_grididx(g, c) .== ref)
             end
 
@@ -187,13 +190,13 @@
         @testset "2D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused]
             R = 5
             d = 2
-            grid_min = (0.1, 0.1)
-            grid_max = (2.0, 2.0)
-            dx = (grid_max .- grid_min) ./ (2^R - 1)
+            a = (0.1, 0.1)
+            b = (2.0, 2.0)
+            dx = (b .- a) ./ (2^R - 1)
             g = QuanticsGrids.DiscretizedGrid{d}(
                 R,
-                grid_min,
-                grid_max;
+                a,
+                b;
                 unfoldingscheme,
                 includeendpoint=true,
             )

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -1,14 +1,14 @@
 
 @testitem "grid.jl" begin
     using Test
-    import QuanticsGrids as QD
+    import QuanticsGrids
 
 
     @testset "quanticsfunction" begin
         R = 8
-        grid = QD.DiscretizedGrid{1}(R, 0.0, 1.0)
+        grid = QuanticsGrids.DiscretizedGrid{1}(R, 0.0, 1.0)
         fx(x) = exp(-x)
-        fq = QD.quanticsfunction(Float64, grid, fx)
+        fq = QuanticsGrids.quanticsfunction(Float64, grid, fx)
 
         @test fq(ones(Int, R)) == fx(0.0)
         @test fq(fill(2, R)) ≈ fx(1.0 - 1 / 2^R)
@@ -16,41 +16,41 @@
 
     @testset "1D grid (large R)" begin
         R = 62
-        grid = QD.DiscretizedGrid{1}(R, 0.0, 1.0)
-        @test QD.grididx_to_quantics(grid, 2^R) == fill(2, R)
+        grid = QuanticsGrids.DiscretizedGrid{1}(R, 0.0, 1.0)
+        @test QuanticsGrids.grididx_to_quantics(grid, 2^R) == fill(2, R)
     end
 
     @testset "2D grid (large R)" for base in [2]
         R = 62
         d = 2
-        grid = QD.DiscretizedGrid{d}(R, 0.0, 1.0; base=base)
-        @test QD.grididx_to_quantics(grid, ntuple(i -> base^R, d)) == fill(base^d, R)
+        grid = QuanticsGrids.DiscretizedGrid{d}(R, 0.0, 1.0; base=base)
+        @test QuanticsGrids.grididx_to_quantics(grid, ntuple(i -> base^R, d)) == fill(base^d, R)
     end
 
     @testset "1D grid (too large R)" begin
         R = 64
-        @test_throws ErrorException QD.DiscretizedGrid{1}(R, 0.0, 1.0)
+        @test_throws ErrorException QuanticsGrids.DiscretizedGrid{1}(R, 0.0, 1.0)
     end
 
     @testset "grid representation conversion" for R in [10]
         reprs = [:grididx, :quantics, :origcoord]
 
         testset = [
-            (QD.DiscretizedGrid{1}(R, 0.0, 1.0), 2),
-            (QD.DiscretizedGrid{2}(R, (0.0, 0.0), (1.0, 1.0)), (2, 3)),
-            (QD.InherentDiscreteGrid{1}(R), 2),
-            (QD.InherentDiscreteGrid{2}(R), (2, 3)),
+            (QuanticsGrids.DiscretizedGrid{1}(R, 0.0, 1.0), 2),
+            (QuanticsGrids.DiscretizedGrid{2}(R, (0.0, 0.0), (1.0, 1.0)), (2, 3)),
+            (QuanticsGrids.InherentDiscreteGrid{1}(R), 2),
+            (QuanticsGrids.InherentDiscreteGrid{2}(R), (2, 3)),
         ]
         for (grid, ini_grididx) in testset
 
             data = Dict{Symbol,Any}()
             transforms = Dict(
-                (:grididx, :quantics) => QD.grididx_to_quantics,
-                (:grididx, :origcoord) => QD.grididx_to_origcoord,
-                (:quantics, :grididx) => QD.quantics_to_grididx,
-                (:quantics, :origcoord) => QD.quantics_to_origcoord,
-                (:origcoord, :grididx) => QD.origcoord_to_grididx,
-                (:origcoord, :quantics) => QD.origcoord_to_quantics,
+                (:grididx, :quantics) => QuanticsGrids.grididx_to_quantics,
+                (:grididx, :origcoord) => QuanticsGrids.grididx_to_origcoord,
+                (:quantics, :grididx) => QuanticsGrids.quantics_to_grididx,
+                (:quantics, :origcoord) => QuanticsGrids.quantics_to_origcoord,
+                (:origcoord, :grididx) => QuanticsGrids.origcoord_to_grididx,
+                (:origcoord, :quantics) => QuanticsGrids.origcoord_to_quantics,
             )
 
             data[:grididx] = ini_grididx
@@ -181,7 +181,7 @@
             cs = [
                 0.999999 .* dx .+ a,
                 1.999999 .* dx .+ a,
-                b .- 1e-9 .* dx,
+                b .- dx .- 1e-9 .* dx,
             ]
             refs = [2, 3, 2^R]
 


### PR DESCRIPTION
- Adds `lower_bound` and `upper_bound` functions, which give the boundaries of the grid
- `grid_max` has been redefined to return the last grid point. The previous functionality is available through the `upper_bound` function.