### PR TITLE
Determine dimensions from arguments and fixed typos in documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,7 @@ julia> using Pkg; Pkg.add("QuanticsGrids.jl")
 
 ## Definition
 We first introduce a $B$-base presentation ($B=2, 3, 4, \cdots$).
-To avoid confusing, we will use the 1-based indexing of Julia below.
+To avoid confusion, we will use the 1-based indexing of Julia below.
 We represent a positive integer $X~(\ge 1)$ as
 
 ```math
@@ -64,13 +64,13 @@ with
 ```
 
 This convention is consistent with the column major used in Julia: At each digit level $i$, the bit for $x$ runs fastest.
-The fused representaion generalizes to any number of variables.
+The fused representation generalizes to any number of variables.
 
 
 ## Usage
 This package contains two main functionalities:
 
-1. Low-level functions for converting betwen linear and quantics representations
+1. Low-level functions for converting between linear and quantics representations
 2. High-level interface for creating a grid
 
 The normal users will use the second high-level interface.
@@ -92,8 +92,8 @@ grid = QG.DiscretizedGrid{1}(R, xmin, xmax)
 ```
 
 Here, `DiscretizedGrid` takes one parameter `1`, which denotes the dimension of the grid.
-There are six functions for translating between different reprenstations:
-`grididx` (1-based linear index), `quantics` and `origcoord` (original coordiate, i.e., $x$).
+There are six functions for translating between different representations:
+`grididx` (1-based linear index), `quantics` and `origcoord` (original coordinate, i.e., $x$).
 In `origcoord_to_quantics` and `origcoord_to_grididx`, if `origcoord` is out of the grid, the function returns the closest point in the grid.
 
 Example:
@@ -201,7 +201,7 @@ grididx = (2, 1, 1)
 
 ## Inherent discrete grid
 `InherentDiscreteGrid` can be used if the target space is discrete.
-`InherentDiscreteGrid`  has a very similar interface to `DiscretizedGrid`.
+`InherentDiscreteGrid` has a very similar interface to `DiscretizedGrid`.
 We provide one example.
 
 ```@example simple
@@ -255,7 +255,7 @@ grididx = base^R
 
 ## Create a function that takes a quantics index as its input
 When using `QuanticsGrids.jl` in combination with `TensorCrossInterpolation.jl`,
-one can wrap a function to be interpolated to make a fuction that takes a quantics index:
+one can wrap a function to be interpolated to make a function that takes a quantics index:
 
 ```@example simple
 import QuanticsGrids as QG

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -54,7 +54,7 @@ Conversion between grid index, original coordinate, quantics
 grid index => original coordinate
 """
 function grididx_to_origcoord(g::Grid{d}, index::NTuple{d,Int}) where {d}
-    all(1 .<= index .<= g.base^g.R) || error("1 <= {index} <= g.base^g.R")
+    all(1 .<= index .<= g.base^g.R) || error("1 <= $index <= g.base^g.R")
     return _convert_to_scalar_if_possible((index .- 1) .* grid_step(g) .+ grid_min(g))
 end
 

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -165,6 +165,36 @@ struct InherentDiscreteGrid{d} <: Grid{d}
 
 end
 
+function InherentDiscreteGrid(
+    R::Int,
+    origin::Int;
+    base::Integer=2,
+    unfoldingscheme::Symbol=:fused,
+    step::Int=1,
+)
+    return InherentDiscreteGrid{1}(
+        R, origin;
+        base=base,
+        unfoldingscheme=unfoldingscheme,
+        step=step,
+    )
+end
+
+function InherentDiscreteGrid(
+    R::Int,
+    origin::NTuple{N, Int};
+    base::Integer=2,
+    unfoldingscheme::Symbol=:fused,
+    step::Union{Int, NTuple{N, Int}}=1,
+) where {N}
+    return InherentDiscreteGrid{N}(
+        R, origin;
+        base=base,
+        unfoldingscheme=unfoldingscheme,
+        step=step,
+    )
+end
+
 grid_min(grid::InherentDiscreteGrid) = _convert_to_scalar_if_possible(grid.origin)
 grid_step(grid::InherentDiscreteGrid{d}) where {d} =
     _convert_to_scalar_if_possible(grid.step)
@@ -249,6 +279,38 @@ struct DiscretizedGrid{d} <: Grid{d}
             includeendpoint,
         )
     end
+end
+
+function DiscretizedGrid(
+    R::Int,
+    grid_min::T,
+    grid_max::T;
+    base::Integer=2,
+    unfoldingscheme::Symbol=:fused,
+    includeendpoint::Bool=false,
+) where {T <: Real}
+    return DiscretizedGrid{1}(
+        R, (grid_min,), (grid_max,);
+        base=base,
+        unfoldingscheme=unfoldingscheme,
+        includeendpoint=includeendpoint,
+    )
+end
+
+function DiscretizedGrid(
+    R::Int,
+    grid_min::NTuple{N, T},
+    grid_max::NTuple{N, T};
+    base::Integer=2,
+    unfoldingscheme::Symbol=:fused,
+    includeendpoint::Bool=false,
+) where {N, T <: Real}
+    return DiscretizedGrid{N}(
+        R, grid_min, grid_max;
+        base=base,
+        unfoldingscheme=unfoldingscheme,
+        includeendpoint=includeendpoint,
+    )
 end
 
 grid_min(g::DiscretizedGrid) = _convert_to_scalar_if_possible(g.grid_min)

--- a/src/quantics.jl
+++ b/src/quantics.jl
@@ -104,7 +104,7 @@ function deinterleave_dimensions!(
 end
 
 """
-Converrt a fused qunaitcs representation to an unfused quantics representation
+Convert a fused quantics representation to an unfused quantics representation
 """
 function fused_to_interleaved(
     digitlist::AbstractVector{T},
@@ -115,7 +115,7 @@ function fused_to_interleaved(
 end
 
 """
-Converrt a unfused qunaitcs representation to an fused quantics representation
+Convert an unfused quantics representation to an fused quantics representation
 """
 function interleaved_to_fused(
     digitlist::AbstractVector{T};

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -207,4 +207,30 @@
             end
         end
     end
+
+    @testset "dimension inference constructors" begin
+        g1 = QD.DiscretizedGrid(4, 0.0, 1.0)
+        @test g1 isa QD.DiscretizedGrid{1}
+        @test g1.grid_min == (0.0,)
+        @test g1.grid_max == (1.0,)
+
+        g2 = QD.DiscretizedGrid(4, (0.0, 0.0), (1.0, 1.0))
+        @test g2 isa QD.DiscretizedGrid{2}
+        @test g2.grid_min == (0.0, 0.0)
+        @test g2.grid_max == (1.0, 1.0)
+
+        g6 = QD.DiscretizedGrid(6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
+        @test g6 isa QD.DiscretizedGrid{6}
+        @test g6.grid_min == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        @test g6.grid_max == (1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+
+        g3 = QD.InherentDiscreteGrid(4, 1)
+        @test g3 isa QD.InherentDiscreteGrid{1}
+        @test g3.origin == (1,)
+
+        g4 = QD.InherentDiscreteGrid(4, (1, 2, 3); step=(1, 2, 1))
+        @test g4 isa QD.InherentDiscreteGrid{3}
+        @test g4.origin == (1, 2, 3)
+        @test g4.step == (1, 2, 1)
+    end
 end


### PR DESCRIPTION
I noticed some typos in the documentation and updated `DiscretizedGrid` and `InherentDiscreteGrid` to determine the dimension from the number of arguments mentioned in #5. As an example

```julia
DiscretizedGrid(4, 0.0, 1.0)               
DiscretizedGrid(4, (0.0, 0.0), (1.0, 1.0)) 
```
now creates:
```julia
DiscretizedGrid{1}(4, (0.0,), (1.0,), 2, :fused, false)
DiscretizedGrid{2}(4, (0.0, 0.0), (1.0, 1.0), 2, :fused, false)
```