### PR TITLE
Add `:serial` and `:meander` unfolding schemes

### DIFF
--- a/src/grid.jl
+++ b/src/grid.jl
@@ -68,6 +68,18 @@ grid index => quantics
 function grididx_to_quantics(g::Grid{d}, grididx::NTuple{d,Int}) where {d}
     if g.unfoldingscheme === :fused
         return index_to_quantics_fused(grididx, numdigits = g.R, base = g.base)
+    elseif g.unfoldingscheme === :serial
+        return fused_to_serial(
+            index_to_quantics_fused(grididx, numdigits = g.R, base = g.base),
+            d,
+            base = g.base,
+        )
+    elseif g.unfoldingscheme === :meander
+        return fused_to_meander(
+            index_to_quantics_fused(grididx, numdigits = g.R, base = g.base),
+            d,
+            base = g.base,
+        )
     else
         return fused_to_interleaved(
             index_to_quantics_fused(grididx, numdigits = g.R, base = g.base),
@@ -155,7 +167,7 @@ struct InherentDiscreteGrid{d} <: Grid{d}
         step::Union{NTuple{d,Int},Int} = 1,
     ) where {d}
         _rangecheck_R(R; base = base)
-        unfoldingscheme in (:fused, :interleaved) ||
+        unfoldingscheme in (:fused, :interleaved, :serial, :meander) ||
             error("Invalid unfolding scheme: $unfoldingscheme")
         origin_ = origin isa Int ? ntuple(i -> origin, d) : origin
         step_ = step isa Int ? ntuple(i -> step, d) : step
@@ -305,7 +317,7 @@ struct DiscretizedGrid{d} <: Grid{d}
         includeendpoint::Bool = false,
     ) where {d}
         _rangecheck_R(R; base = base)
-        unfoldingscheme in (:fused, :interleaved) ||
+        unfoldingscheme in (:fused, :interleaved, :serial, :meander) ||
             error("Invalid unfolding scheme: $unfoldingscheme")
         return new(
             R,

--- a/test/grid_tests.jl
+++ b/test/grid_tests.jl
@@ -79,7 +79,7 @@
         end
     end
 
-    @testset "InherentDiscreteGrid" for unfoldingscheme in [:interleaved, :fused],
+    @testset "InherentDiscreteGrid" for unfoldingscheme in [:interleaved, :fused, :serial, :meander],
         step in [(1, 1, 1), (1, 1, 2)],
         origin in [(1, 1, 1), (1, 1, 2)]
 
@@ -87,7 +87,7 @@
         @test QuanticsGrids.grid_min(m) == origin
         @test QuanticsGrids.grid_step(m) == step
 
-        if unfoldingscheme === :interleaved
+        if unfoldingscheme === :interleaved || unfoldingscheme === :serial || unfoldingscheme === :meander
             @test QuanticsGrids.localdimensions(m) == fill(2, 3 * 5)
         else
             @test QuanticsGrids.localdimensions(m) == fill(2^3, 5)
@@ -108,7 +108,7 @@
         end
     end
 
-    @testset "DiscretizedGrid" for unfoldingscheme in [:interleaved, :fused]
+    @testset "DiscretizedGrid" for unfoldingscheme in [:interleaved, :fused, :serial, :meander]
         @testset "1D" begin
             unfoldingscheme = :interleaved
 
@@ -134,7 +134,7 @@
             @test QuanticsGrids.grid_step(g) == 0.059375
         end
 
-        @testset "1D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused]
+        @testset "1D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused, :serial, :meander]
             R = 5
             a = 0.0
             b = 1.0
@@ -159,7 +159,7 @@
             @test only(QuanticsGrids.quantics_to_origcoord(g, fill(2, R))) == b
         end
 
-        @testset "2D" for unfoldingscheme in [:interleaved, :fused]
+        @testset "2D" for unfoldingscheme in [:interleaved, :fused, :serial, :meander]
             R = 5
             d = 2
             a = (0.1, 0.1)
@@ -167,7 +167,7 @@
             dx = (b .- a) ./ 2^R
             g = QuanticsGrids.DiscretizedGrid{d}(R, a, b; unfoldingscheme)
 
-            if unfoldingscheme === :interleaved
+            if unfoldingscheme === :interleaved || unfoldingscheme === :serial || unfoldingscheme === :meander
                 @test QuanticsGrids.localdimensions(g) == fill(2, d * R)
             else
                 @test QuanticsGrids.localdimensions(g) == fill(2^d, R)
@@ -197,7 +197,7 @@
             @test_throws "Bound Error:" QuanticsGrids.origcoord_to_grididx(g, (3.0, 3.0))
         end
 
-        @testset "2D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused]
+        @testset "2D (includeendpoint)" for unfoldingscheme in [:interleaved, :fused, :serial, :meander]
             R = 5
             d = 2
             a = (0.1, 0.1)
@@ -213,7 +213,7 @@
             @test g.includeendpoint
             @test QuanticsGrids.grid_step(g) == dx
 
-            if unfoldingscheme === :interleaved
+            if unfoldingscheme === :interleaved || unfoldingscheme === :serial || unfoldingscheme === :meander
                 @test QuanticsGrids.localdimensions(g) == fill(2, d * R)
             else
                 @test QuanticsGrids.localdimensions(g) == fill(2^d, R)

--- a/test/quantics_test.jl
+++ b/test/quantics_test.jl
@@ -2,6 +2,8 @@
     import QuanticsGrids: fuse_dimensions, unfuse_dimensions
     import QuanticsGrids: quantics_to_index_fused, index_to_quantics
     import QuanticsGrids: interleave_dimensions, deinterleave_dimensions
+    import QuanticsGrids: serialize_dimensions, deserialize_dimensions
+    import QuanticsGrids: meander_dimensions, demeander_dimensions
 
     @testset "quantics representation" begin
         @testset "fuse_dimensions" begin
@@ -98,6 +100,44 @@
                   [[1, 1, 1, 1], [2, 3, 4, 5]]
             @test deinterleave_dimensions([1, 2, 11, 1, 3, 12, 1, 4, 13, 1, 5, 14], 3) ==
                   [[1, 1, 1, 1], [2, 3, 4, 5], [11, 12, 13, 14]]
+        end
+
+        @testset "serial dimensions" begin
+            @test [1, 1, 1, 1] == serialize_dimensions([1, 1, 1, 1])
+            @test [1, 1, 1, 1, 1, 1, 1, 1] ==
+                  serialize_dimensions([1, 1, 1, 1], [1, 1, 1, 1])
+            @test [1, 1, 1, 1, 2, 3, 4, 5] ==
+                  serialize_dimensions([1, 1, 1, 1], [2, 3, 4, 5])
+            @test [1, 1, 1, 1, 2, 3, 4, 5, 11, 12, 13, 14] ==
+                  serialize_dimensions([1, 1, 1, 1], [2, 3, 4, 5], [11, 12, 13, 14])
+        end
+
+        @testset "deserial dimensions" begin
+            @test deserialize_dimensions([1, 1, 1, 1], 1) == [[1, 1, 1, 1]]
+            @test deserialize_dimensions([1, 1, 1, 1], 2) == [[1, 1], [1, 1]]
+            @test deserialize_dimensions([1, 2, 1, 3, 1, 4, 1, 5], 2) ==
+                  [[1, 2, 1, 3], [1, 4, 1, 5]]
+            @test deserialize_dimensions([1, 2, 11, 1, 3, 12, 1, 4, 13, 1, 5, 14], 3) ==
+                  [[1, 2, 11, 1], [3, 12, 1, 4], [13, 1, 5, 14]]
+        end
+
+        @testset "meander dimensions" begin
+            @test [1, 1, 1, 1] == meander_dimensions([1, 1, 1, 1])
+            @test [1, 1, 1, 1, 1, 1, 1, 1] ==
+                  meander_dimensions([1, 1, 1, 1], [1, 1, 1, 1])
+            @test [1, 1, 1, 1, 2, 3, 4, 5] ==
+                  meander_dimensions([1, 1, 1, 1], [2, 3, 4, 5])
+            @test [1, 1, 1, 1, 2, 3, 4, 5, 11, 12, 13, 14] ==
+                  meander_dimensions([1, 1, 1, 1], [2, 3, 4, 5], [14, 13, 12, 11])
+        end
+
+        @testset "demeander dimensions" begin
+            @test demeander_dimensions([1, 1, 1, 1], 1) == [[1, 1, 1, 1]]
+            @test demeander_dimensions([1, 1, 1, 1], 2) == [[1, 1], [1, 1]]
+            @test demeander_dimensions([1, 2, 1, 3, 1, 4, 1, 5], 2) ==
+                  [[3, 1, 2, 1], [1, 4, 1, 5]]
+            @test demeander_dimensions([1, 2, 11, 1, 3, 12, 1, 4, 13, 1, 5, 14], 3) ==
+                  [[1, 11, 2, 1], [3, 12, 1, 4], [14, 5, 1, 13]]
         end
     end
 end


### PR DESCRIPTION
These unfolding schemes complement the already implemented :interleaved and :fused schemes. I wrote them up for a project testing the performance of different quantics bases for multivariate functions in different settings. It's possible they could be of use to others. If the package maintainers disagree and want to close this PR, that's perfectly fine! If it gets merged I can follow up with a PR to QuanticsTCI.jl for support in the TCI interface.