### PR TITLE
Fix mixed-type bounds handling in DiscretizedGrid

### DIFF
--- a/src/grid.jl
+++ b/src/grid.jl
@@ -56,8 +56,13 @@ end
 _convert_to_scalar_if_possible(x) = x
 _convert_to_scalar_if_possible(x::NTuple{1,T}) where {T} = first(x)
 
-_to_tuple(::Val{d}, x::NTuple{d}) where {d} = x
-_to_tuple(::Val{d}, x) where {d} = ntuple(i -> x, d)
+function _to_tuple(::Val{d}, x::Tuple) where {d}
+    if length(x) != d
+        throw(ArgumentError(lazy"Got tuple with length $(length(x)); expected $d."))
+    end
+    return x
+end
+_to_tuple(::Val{d}, x) where {d} = ntuple(Returns(x), d)
 
 _all_base_two(base::NTuple{D,Int}) where {D} = all(==(2), base)
 

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -56,13 +56,8 @@ end
 _convert_to_scalar_if_possible(x) = x
 _convert_to_scalar_if_possible(x::NTuple{1,T}) where {T} = first(x)
 
-function _to_tuple(::Val{d}, x::Tuple) where {d}
-    if length(x) != d
-        throw(ArgumentError(lazy"Got tuple with length $(length(x)); expected $d."))
-    end
-    return x
-end
-_to_tuple(::Val{d}, x) where {d} = ntuple(Returns(x), d)
+_to_tuple(::Val{d}, x::NTuple{d}) where {d} = x
+_to_tuple(::Val{d}, x) where {d} = ntuple(i -> x, d)
 
 _all_base_two(base::NTuple{D,Int}) where {D} = all(==(2), base)
 

--- a/src/grid_discretized.jl
+++ b/src/grid_discretized.jl
@@ -119,10 +119,10 @@ end
 # ============================================================================
 
 function _check_bounds_dim(::Val{D}, lower_bound, upper_bound) where {D}
-    if lower_bound isa NTuple && length(lower_bound) != D
+    if lower_bound isa Tuple && length(lower_bound) != D
         throw(ArgumentError(lazy"Got lower_bound with length $(length(lower_bound)); expected $D for DiscretizedGrid{$D}."))
     end
-    if upper_bound isa NTuple && length(upper_bound) != D
+    if upper_bound isa Tuple && length(upper_bound) != D
         throw(ArgumentError(lazy"Got upper_bound with length $(length(upper_bound)); expected $D for DiscretizedGrid{$D}."))
     end
 end

--- a/src/grid_discretized.jl
+++ b/src/grid_discretized.jl
@@ -94,8 +94,8 @@ struct DiscretizedGrid{D} <: Grid{D}
     function DiscretizedGrid{D}(
         Rs, lower_bound, upper_bound, variablenames, base, indextable, includeendpoint
     ) where {D}
-        lower_bound = _to_tuple(Val(D), lower_bound)
-        upper_bound = _to_tuple(Val(D), upper_bound)
+        lower_bound = _to_float_tuple(Val(D), lower_bound)
+        upper_bound = _to_float_tuple(Val(D), upper_bound)
         base = _to_tuple(Val(D), base)
         includeendpoint = _to_tuple(Val(D), includeendpoint)
         for d in 1:D
@@ -126,6 +126,15 @@ function _check_bounds_dim(::Val{D}, lower_bound, upper_bound) where {D}
         throw(ArgumentError(lazy"Got upper_bound with length $(length(upper_bound)); expected $D for DiscretizedGrid{$D}."))
     end
 end
+
+function _to_float_tuple(::Val{D}, x::Tuple) where {D}
+    if length(x) != D
+        throw(ArgumentError(lazy"Got tuple with length $(length(x)); expected $D."))
+    end
+    return ntuple(d -> Float64(x[d]), D)
+end
+
+_to_float_tuple(::Val{D}, x) where {D} = ntuple(_ -> Float64(x), D)
 
 function _adjust_upper_bounds(upper_bound, lower_bound, includeendpoint, base, Rs, ::Val{D}) where D
     base = _to_tuple(Val(D), base)

--- a/test/discretizedgrid_misc_tests.jl
+++ b/test/discretizedgrid_misc_tests.jl
@@ -52,6 +52,15 @@ end
     @test_throws ArgumentError DiscretizedGrid{2}(3, (0.0, 1.0), (1.0,))
 end
 
+@testitem "DiscretizedGrid mixed-type bounds" begin
+    R = 10
+    N = 2^R
+    g = DiscretizedGrid{2}((R, R), (0.0, 0), (2.0, N - 1); includeendpoint=(false, true))
+
+    @test QuanticsGrids.lower_bound(g) == (0.0, 0.0)
+    @test QuanticsGrids.grid_max(g)[2] ≈ N - 1
+end
+
 @testitem "DiscretizedGrid 0-dimensional show method" begin
     g = DiscretizedGrid(())
     @test try


### PR DESCRIPTION
## Summary
- accept heterogeneous tuples in `_to_tuple` as long as tuple length matches dimension, so `(0.0, 0)` bounds work correctly
- run dimension checks for all tuple bounds (not only `NTuple`) to keep error messages consistent
- add a regression test covering mixed-type bounds with `includeendpoint`

Closes #30.