### PR TITLE
Accept untyped indextable containers in grid constructors

### DIFF
--- a/src/grid_discretized.jl
+++ b/src/grid_discretized.jl
@@ -211,12 +211,13 @@ end
 
 function DiscretizedGrid(
     variablenames::NTuple{D,Symbol},
-    indextable::Vector{Vector{Tuple{Symbol,Int}}};
+    indextable::AbstractVector;
     lower_bound=default_lower_bound(Val(D)),
     upper_bound=default_upper_bound(Val(D)),
     base=2,
     includeendpoint=false
 ) where D
+    indextable = _normalize_indextable(indextable)
     Rs = map(variablenames) do variablename
         count(index -> first(index) == variablename, Iterators.flatten(indextable))
     end

--- a/test/discretizedgrid_misc_tests.jl
+++ b/test/discretizedgrid_misc_tests.jl
@@ -47,6 +47,24 @@ end
     @test g.discretegrid.lookup_table == g´.discretegrid.lookup_table == g´´.discretegrid.lookup_table
 end
 
+@testitem "DiscretizedGrid accepts untyped indextable container" begin
+    R = 10
+    N = 2^R
+    lower_bound = (0.0, 0.0)
+    upper_bound = (2.0, N - 1.0)
+
+    indextable = []
+    for l in 1:R
+        push!(indextable, [(:w, l)])
+        push!(indextable, [(:n, R - l + 1)])
+    end
+
+    g = DiscretizedGrid((:w, :n), indextable; lower_bound, upper_bound, includeendpoint=(false, true))
+    @test QuanticsGrids.grid_variablenames(g) == (:w, :n)
+    @test length(QuanticsGrids.grid_indextable(g)) == 2R
+    @test QuanticsGrids.grid_max(g)[2] ≈ N - 1
+end
+
 @testitem "DiscretizedGrid dimension mismatch for bounds" begin
     @test_throws ArgumentError DiscretizedGrid{2}(3, (0.0,), (1.0, 2.0))
     @test_throws ArgumentError DiscretizedGrid{2}(3, (0.0, 1.0), (1.0,))


### PR DESCRIPTION
## Summary
- relax `DiscretizedGrid` and `InherentDiscreteGrid` index-table constructor signatures to accept generic vectors
- normalize index table entries into `Vector{Vector{Tuple{Symbol,Int}}}` with explicit validation and clear errors
- add a regression test for `indextable = []` plus incremental `push!` construction

Closes #31.