### PR TITLE
Add compact indextable display to DiscretizedGrid show

### DIFF
--- a/test/discretizedgrid_misc_tests.jl
+++ b/test/discretizedgrid_misc_tests.jl
@@ -72,10 +72,9 @@ end
 
 @testitem "DiscretizedGrid show method" begin
     g = DiscretizedGrid((2, 3, 4))
-    @test try
-        sprint(show, g)
-        true
-    catch e
-        false
-    end
+    text = sprint(show, MIME"text/plain"(), g)
+    @test occursin("Index table: [", text)
+    @test occursin("1:(", text)
+    @test !occursin("Symbol(\"", text)
+    @test !occursin("\n│  ", text)
 end


### PR DESCRIPTION
## Summary
- add a readable one-line formatter for index-table sites in the plain-text `DiscretizedGrid` show output
- display entries using `var[bit]` notation and compact truncation for long tables
- update show tests to assert index-table presence and formatting

Closes #32.